### PR TITLE
視点の回転＋補助線の回転最適化＋補助線の角度がおかしくなるバグ修正

### DIFF
--- a/Frisbee/Assets/Prefabs/Frisbee.prefab
+++ b/Frisbee/Assets/Prefabs/Frisbee.prefab
@@ -1,5 +1,170 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4017317567309925109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6346494722386812334}
+  - component: {fileID: 2034819497849808541}
+  - component: {fileID: 2705428613813045583}
+  - component: {fileID: 8522325600842921248}
+  m_Layer: 0
+  m_Name: Direction
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6346494722386812334
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017317567309925109}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.4, y: 0, z: 4.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5526890942020377915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2034819497849808541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017317567309925109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 87e9f96f6dfa4abeb02580a948e09f0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  frisbee: {fileID: 5526890942020377915}
+--- !u!120 &2705428613813045583
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017317567309925109}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 828e60e77b7d3fe46b5169712534c877, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.04842186
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!114 &8522325600842921248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017317567309925109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29eb2be2abc74a92948874306c5899f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  centerObj: {fileID: 9210741682833451940}
+  angle: 75
 --- !u!1 &9210741682833451940
 GameObject:
   m_ObjectHideFlags: 0
@@ -16,6 +181,7 @@ GameObject:
   - component: {fileID: 4509150488614362334}
   - component: {fileID: 8499073135286176261}
   - component: {fileID: -1577073067109545091}
+  - component: {fileID: 4768745020616102860}
   m_Layer: 0
   m_Name: Frisbee
   m_TagString: Frisbee
@@ -33,10 +199,11 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -32.4, y: -17.797956, z: -7.6805425}
-  m_LocalScale: {x: 0.29206452, y: 0.049981, z: 0.29206452}
+  m_LocalScale: {x: 0.24, y: 0.04, z: 0.24}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1944546522794292854}
+  - {fileID: 6346494722386812334}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &702901462180792688
@@ -96,7 +263,7 @@ BoxCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9210741682833451940}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: f4e33826cbbc67d498d9e0e2186d255c, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -151,8 +318,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   node: 5
   beforeVer: 0
-  controlPower: {x: 10, y: 2, z: 10}
-  upScale: 0
+  controlPower: {x: 10, y: 10, z: 10}
+  upScale: 1
 --- !u!114 &8499073135286176261
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,7 +334,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _cameraRig: {fileID: 0}
   _frisParent: {fileID: 0}
-  moveSpeed: 5
+  moveSpeed: 4
 --- !u!114 &-1577073067109545091
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -180,9 +347,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 246fe5c0d5764bf1aa7230f1eedb2178, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 2000171639455669151, guid: 07e9e479cf3153a4cac4b82ea621099a, type: 3}
-  gameManager: {fileID: 0}
+  player: {fileID: 0}
+  gameManager: {fileID: 3153735085271485672, guid: 4bd0f96c4b836e84096f7da4df3c7059, type: 3}
   fireGameObject: {fileID: 5523813300628688629, guid: 2cc2a863427c24a44a670fb7891e57db, type: 3}
+--- !u!114 &4768745020616102860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9210741682833451940}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0635ab95c0074ead9e06f70ea677069f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scalePower: {x: 10, y: 3, z: 10}
 --- !u!1001 &5506059254415443178
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Frisbee/Assets/Prefabs/[BuildingBlock] Camera Rig.prefab
+++ b/Frisbee/Assets/Prefabs/[BuildingBlock] Camera Rig.prefab
@@ -2067,6 +2067,7 @@ GameObject:
   - component: {fileID: 1526823158702821032}
   - component: {fileID: 6893152178819078041}
   - component: {fileID: 5190338637641010828}
+  - component: {fileID: 5922374297102574306}
   m_Layer: 0
   m_Name: '[BuildingBlock] Camera Rig'
   m_TagString: Player
@@ -2249,6 +2250,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   divisor: 2.5
+--- !u!114 &5922374297102574306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000171639455669151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf42c156ec634962b5d7613df257c27b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotateAmount: 1
 --- !u!1 &2158201808662475559
 GameObject:
   m_ObjectHideFlags: 0
@@ -2348,171 +2362,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 3825733597987261148}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2291278928111176893
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7628519482548074004}
-  - component: {fileID: 4813635418827004264}
-  - component: {fileID: 7469170307427800100}
-  - component: {fileID: 8171796527801898943}
-  m_Layer: 0
-  m_Name: Direction
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7628519482548074004
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2291278928111176893}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.4, y: 0, z: 4.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8115145289976154061}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4813635418827004264
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2291278928111176893}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 87e9f96f6dfa4abeb02580a948e09f0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  frisbee: {fileID: 8115145289976154061}
---- !u!120 &7469170307427800100
-LineRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2291278928111176893}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 0
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 828e60e77b7d3fe46b5169712534c877, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Positions:
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0, z: 1}
-  m_Parameters:
-    serializedVersion: 3
-    widthMultiplier: 1
-    widthCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0.04842186
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    colorGradient:
-      serializedVersion: 2
-      key0: {r: 1, g: 1, b: 1, a: 1}
-      key1: {r: 1, g: 1, b: 1, a: 1}
-      key2: {r: 0, g: 0, b: 0, a: 0}
-      key3: {r: 0, g: 0, b: 0, a: 0}
-      key4: {r: 0, g: 0, b: 0, a: 0}
-      key5: {r: 0, g: 0, b: 0, a: 0}
-      key6: {r: 0, g: 0, b: 0, a: 0}
-      key7: {r: 0, g: 0, b: 0, a: 0}
-      ctime0: 0
-      ctime1: 65535
-      ctime2: 0
-      ctime3: 0
-      ctime4: 0
-      ctime5: 0
-      ctime6: 0
-      ctime7: 0
-      atime0: 0
-      atime1: 65535
-      atime2: 0
-      atime3: 0
-      atime4: 0
-      atime5: 0
-      atime6: 0
-      atime7: 0
-      m_Mode: 0
-      m_ColorSpace: 0
-      m_NumColorKeys: 2
-      m_NumAlphaKeys: 2
-    numCornerVertices: 0
-    numCapVertices: 0
-    alignment: 0
-    textureMode: 0
-    textureScale: {x: 1, y: 1}
-    shadowBias: 0.5
-    generateLightingData: 0
-  m_MaskInteraction: 0
-  m_UseWorldSpace: 1
-  m_Loop: 0
-  m_ApplyActiveColorSpace: 1
---- !u!114 &8171796527801898943
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2291278928111176893}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 29eb2be2abc74a92948874306c5899f3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  centerObj: {fileID: 4899528682813501778}
-  angle: 75
 --- !u!1 &2295499554122645659
 GameObject:
   m_ObjectHideFlags: 0
@@ -11312,18 +11161,6 @@ PrefabInstance:
       propertyPath: player
       value: 
       objectReference: {fileID: 2000171639455669151}
-    - target: {fileID: -1577073067109545091, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      propertyPath: gameManager
-      value: 
-      objectReference: {fileID: 3153735085271485672, guid: 4bd0f96c4b836e84096f7da4df3c7059, type: 3}
-    - target: {fileID: 4509150488614362334, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      propertyPath: upScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4509150488614362334, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      propertyPath: controlPower.y
-      value: 10
-      objectReference: {fileID: 0}
     - target: {fileID: 5526890942020377915, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -11364,14 +11201,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8303858905156687027, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      propertyPath: m_Material
-      value: 
-      objectReference: {fileID: 13400000, guid: f4e33826cbbc67d498d9e0e2186d255c, type: 2}
-    - target: {fileID: 8499073135286176261, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      propertyPath: moveSpeed
-      value: 4
-      objectReference: {fileID: 0}
     - target: {fileID: 8499073135286176261, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
       propertyPath: _cameraRig
       value: 
@@ -11380,39 +11209,24 @@ PrefabInstance:
       propertyPath: _frisParent
       value: 
       objectReference: {fileID: 134556042438603921}
+    - target: {fileID: 8522325600842921248, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
+      propertyPath: magnification
+      value: 85
+      objectReference: {fileID: 0}
     - target: {fileID: 9210741682833451940, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
       propertyPath: m_Name
       value: Frisbee
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 5526890942020377915, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7628519482548074004}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 9210741682833451940, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7313613631383709073}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
 --- !u!1 &4899528682813501778 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9210741682833451940, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}
   m_PrefabInstance: {fileID: 4336332720256080630}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &7313613631383709073
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4899528682813501778}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0635ab95c0074ead9e06f70ea677069f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  scalePower: {x: 10, y: 3, z: 10}
 --- !u!4 &8115145289976154061 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5526890942020377915, guid: 7c8fe0a8574199f44a7851209a59795d, type: 3}

--- a/Frisbee/Assets/Scripts/Furusawa/CameraRotate.cs
+++ b/Frisbee/Assets/Scripts/Furusawa/CameraRotate.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+
+namespace Furusawa
+{
+    public class CameraRotate : MonoBehaviour
+    {
+        private Vector2 _leftStickValue;
+        [Header("回転スピードの倍率(推奨1)")]
+        [Range(0f, 3f)]
+        [SerializeField] private float rotateAmount = 1f;
+        void Update ()
+        {
+            //左スティックの入力取得
+            _leftStickValue = OVRInput.Get(OVRInput.RawAxis2D.LThumbstick);
+
+            Rotate(_leftStickValue);
+        }
+
+        private void Rotate(Vector2 vector)
+        {
+            if (vector.x != 0)
+            {
+               transform.Rotate(0f, vector.x * rotateAmount, 0f);
+            }
+        }
+    }
+}

--- a/Frisbee/Assets/Scripts/Furusawa/CameraRotate.cs.meta
+++ b/Frisbee/Assets/Scripts/Furusawa/CameraRotate.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bf42c156ec634962b5d7613df257c27b
+timeCreated: 1733833785

--- a/Frisbee/Assets/Scripts/Furusawa/GameManager.cs
+++ b/Frisbee/Assets/Scripts/Furusawa/GameManager.cs
@@ -83,7 +83,6 @@ public class GameManager : MonoBehaviour
         // SceneManager.LoadScene(SceneManager.GetActiveScene().name);
         // State = FrisbeeState.Have;
     }
-
     private Vector3 _savePoint;
     public Vector3 SavePoint
     {

--- a/Frisbee/Assets/Scripts/Furusawa/LineRotate.cs
+++ b/Frisbee/Assets/Scripts/Furusawa/LineRotate.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Furusawa
 {
@@ -8,33 +9,26 @@ namespace Furusawa
     {
         [Header("回転の中心(フリスビー)")]
         [SerializeField] GameObject centerObj;
-        
-        [SerializeField][Range(0f, 100f)]  float angle = 50f;
+        [FormerlySerializedAs("angle")]
+        [Header("回転スピードの倍率")]
+        [SerializeField][Range(0f, 100f)]  float magnification = 50f;
 
-        private Vector2 _leftStickValue;
+        private Vector2 _rightStickValue;
         void Update ()
         {
             //左スティックの入力取得
-            _leftStickValue = OVRInput.Get(OVRInput.RawAxis2D.LThumbstick);
+            _rightStickValue = OVRInput.Get(OVRInput.RawAxis2D.RThumbstick);
 
-            Rotate(_leftStickValue);
+            RotateAround(_rightStickValue);
         }
 
-        private void Rotate(Vector2 vector)
+        private void RotateAround(Vector2 vector)
         {
-            if (vector == Vector2.zero)
-                return;
-            
-            // 左スティックを左に倒していたら左回転
-            if (vector.x < 0)
+            // 右スティックを左に倒していたら左回転
+            if (vector.x != 0)
             {
                 //RotateAround(中心の場所,軸,回転角度)
-                transform.RotateAround (centerObj.transform.position, Vector3.up, -angle * Time.deltaTime);
-            }
-            else if (vector.x > 0)
-            {
-                // 右回転
-                transform.RotateAround (centerObj.transform.position, Vector3.up, angle * Time.deltaTime);
+                transform.RotateAround (centerObj.transform.position, transform.up, vector.x * magnification * Time.deltaTime);
             }
         }
     }


### PR DESCRIPTION
## やった事
<!-- このプルリクエストにて何をしたのか？ -->
- 左スティックで視点の回転
- 補助線と視点の回転スピードをスティックの入力量で変化するように最適化
- フリスビーの向きを変えた状態で補助線を回転させると補助線の角度が徐々におかしくなるバグの修正
## Related Issue
close #45 

## 動作確認
<!--
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->
ちゃんと回転するよ

## 備考
<!-- レビュワーがレビューするにあたっての補足情報 -->
- 補助線の回転を右スティック、視点移動を左スティックに変更しました